### PR TITLE
[uwp] Updated latest PDFTron UWP SDK (v8.1) and .NET Core UWP 6.2.11

### DIFF
--- a/ContentPage/UWP/CustomRenderer.UWP.csproj
+++ b/ContentPage/UWP/CustomRenderer.UWP.csproj
@@ -145,13 +145,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
+      <Version>6.2.11</Version>
     </PackageReference>
     <PackageReference Include="PDFTron.UWP">
-      <Version>8.0.2</Version>
+      <Version>8.1.0</Version>
     </PackageReference>
     <PackageReference Include="PDFTron.UWP.Tools">
-      <Version>8.0.2</Version>
+      <Version>8.1.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>4.6.0.800</Version>

--- a/ContentPage/UWP/ViewerPageRenderer.cs
+++ b/ContentPage/UWP/ViewerPageRenderer.cs
@@ -72,6 +72,8 @@ namespace CustomRenderer.UWP
         protected override Size ArrangeOverride(Size finalSize)
         {
             page.Arrange(new Windows.Foundation.Rect(0, 0, finalSize.Width, finalSize.Height));
+            page.UpdateLayout();
+
             return finalSize;
         }
     }


### PR DESCRIPTION
      Fixed issue when resizing Page that caused child objects to not update layout properly